### PR TITLE
Extra arguments to control behaviour of {rstpm2} fitting function

### DIFF
--- a/R/JointFPM.R
+++ b/R/JointFPM.R
@@ -83,6 +83,12 @@
 #'     4      0      6.07  1      0
 #'    ```
 #'
+#' @param control
+#'    List of arguments passed to [rstpm2::gsm.control].
+#'
+#' @param ...
+#'    Additional arguments to be passed to [rstpm2::stpm2].
+#'
 #' @return
 #'    An object of class `JointFPM` with the following elements:
 #'    \describe{
@@ -126,7 +132,9 @@ JointFPM <- function(surv,
                      tvc_re_terms = NULL,
                      tvc_ce_terms = NULL,
                      cluster,
-                     data){
+                     data,
+                     control = list(),
+                     ...){
 
   # Check user inputs ----------------------------------------------------------
 
@@ -264,7 +272,9 @@ JointFPM <- function(surv,
                        tvc.formula = tvc_formula,
                        cluster = data[[cluster]],
                        robust  = TRUE,
-                       data    = data)
+                       data    = data,
+                       control = control,
+                       ...)
 
   out <- list(model        = fpm,
               re_model     = re_model,

--- a/man/JointFPM.Rd
+++ b/man/JointFPM.Rd
@@ -15,7 +15,9 @@ JointFPM(
   tvc_re_terms = NULL,
   tvc_ce_terms = NULL,
   cluster,
-  data
+  data,
+  control = list(),
+  ...
 )
 }
 \arguments{
@@ -83,6 +85,10 @@ times and event indicator for the recurrent event, e.g.:
  4      0      6.07  0      1
  4      0      6.07  1      0
 }\if{html}{\out{</div>}}}
+
+\item{control}{List of arguments passed to \link[rstpm2:gsm.control]{rstpm2::gsm.control}.}
+
+\item{...}{Additional arguments to be passed to \link[rstpm2:gsm]{rstpm2::stpm2}.}
 }
 \value{
 An object of class \code{JointFPM} with the following elements:


### PR DESCRIPTION
Hi @entjos,

A small PR that allows passing `control` and `...` arguments to the fitting function from {rstpm2}. This is motivated by having some models that do not converge (no errors/warnings, but we get very large or very small model coefficients), where we would like to play around with the arguments that control the estimation process.

Let me know if you'd like me to edit this PR further!

Thanks,

Alessandro


P.s., some example code from this PR:

``` r
library(JointFPM)
library(data.table) # For data preparations
bldr_df <- as.data.table(survival::bladder1)
bldr_df <- bldr_df[, .(id, treatment, start, stop, status)]
bldr_ce <- bldr_df[, .SD[stop == max(stop)], by = id]
bldr_ce[, `:=`(ce = 1, re = 0, event = as.numeric(status %in% 2:3), start = 0)]
bldr_re <- bldr_df[, `:=`(ce = 0, re = 1, event = as.numeric(status == 1))]
bldr_stacked <- rbindlist(list(bldr_ce, bldr_re))
bldr_stacked[, `:=`(
  pyridoxine = as.numeric(treatment == "pyridoxine"),
  thiotepa = as.numeric(treatment == "thiotepa")
)]
bldr_stacked$stop[bldr_stacked$stop == 0] <- 1

# Default settings:
bldr_model_default <- JointFPM(
  Surv(
    time = start,
    time2 = stop,
    event = event,
    type = "counting"
  ) ~ 1,
  re_model = ~ pyridoxine + thiotepa,
  ce_model = ~ pyridoxine + thiotepa,
  re_indicator = "re",
  ce_indicator = "ce",
  df_ce = 3,
  df_re = 3,
  tvc_ce_terms = list(
    pyridoxine = 2,
    thiotepa = 2
  ),
  tvc_re_terms = list(
    pyridoxine = 2,
    thiotepa = 2
  ),
  cluster = "id",
  data = bldr_stacked
)

# Alternative control settins:
bldr_model_alt <- JointFPM(
  Surv(
    time = start,
    time2 = stop,
    event = event,
    type = "counting"
  ) ~ 1,
  re_model = ~ pyridoxine + thiotepa,
  ce_model = ~ pyridoxine + thiotepa,
  re_indicator = "re",
  ce_indicator = "ce",
  df_ce = 3,
  df_re = 3,
  tvc_ce_terms = list(
    pyridoxine = 2,
    thiotepa = 2
  ),
  tvc_re_terms = list(
    pyridoxine = 2,
    thiotepa = 2
  ),
  cluster = "id",
  data = bldr_stacked,
  control = list(optimiser = "NelderMead")
)

# Compare:
cbind(
  default = coef(bldr_model_default$model),
  alt = coef(bldr_model_alt$model)
)
#>                                      default         alt
#> ce                               -4.26119784 -4.88877522
#> re                               -3.88216765 -2.84993677
#> ce:pyridoxine                    -0.59655478  0.38906913
#> ce:thiotepa                      -0.59900162  0.39363196
#> re:pyridoxine                     0.16089523 -0.04484277
#> re:thiotepa                       0.87325227 -0.60054857
#> ce:nsx(log(stop), 3)1             2.00351422  2.31897029
#> ce:nsx(log(stop), 3)2             4.30723632  5.07749648
#> ce:nsx(log(stop), 3)3             2.72222970  3.05227260
#> re:nsx(log(stop), 3)1             3.31873438  2.61725213
#> re:nsx(log(stop), 3)2             7.52378236  5.66068007
#> re:nsx(log(stop), 3)3             3.28524605  2.82321418
#> ce:pyridoxine:nsx(log(stop), 2)1  1.44889533 -0.10398340
#> ce:pyridoxine:nsx(log(stop), 2)2 -0.26834876 -0.82523443
#> ce:thiotepa:nsx(log(stop), 2)1    0.90885410 -0.58655823
#> ce:thiotepa:nsx(log(stop), 2)2    1.05531401  0.80050454
#> re:pyridoxine:nsx(log(stop), 2)1 -0.23787432  0.06037834
#> re:pyridoxine:nsx(log(stop), 2)2 -0.08296329  0.01253993
#> re:thiotepa:nsx(log(stop), 2)1   -2.34781263  0.12056282
#> re:thiotepa:nsx(log(stop), 2)2   -0.42711985  0.14045849
```

<sup>Created on 2024-06-17 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

P.p.s.: probably unrelated, but this PR – oddly – did not pass the {testthat} tests on my machine:

```r
==> devtools::check(document = FALSE)

══ Building ═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Setting env vars:
• CFLAGS    : -Wall -pedantic -fdiagnostics-color=always
• CXXFLAGS  : -Wall -pedantic -fdiagnostics-color=always
• CXX11FLAGS: -Wall -pedantic -fdiagnostics-color=always
• CXX14FLAGS: -Wall -pedantic -fdiagnostics-color=always
• CXX17FLAGS: -Wall -pedantic -fdiagnostics-color=always
• CXX20FLAGS: -Wall -pedantic -fdiagnostics-color=always
── R CMD build ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔  checking for file ‘/Users/ellessenne/R-dev/JointFPM/DESCRIPTION’ ...
─  preparing ‘JointFPM’:
✔  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building ‘JointFPM_1.2.0.9000.tar.gz’
   
══ Checking ═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Setting env vars:
• _R_CHECK_CRAN_INCOMING_REMOTE_               : FALSE
• _R_CHECK_CRAN_INCOMING_                      : FALSE
• _R_CHECK_FORCE_SUGGESTS_                     : FALSE
• _R_CHECK_PACKAGES_USED_IGNORE_UNUSED_IMPORTS_: FALSE
• NOT_CRAN                                     : true
── R CMD check ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
─  using log directory ‘/Users/ellessenne/R-dev/JointFPM.Rcheck’
─  using R version 4.4.1 (2024-06-14)
─  using platform: aarch64-apple-darwin20
─  R was compiled by
       Apple clang version 14.0.0 (clang-1400.0.29.202)
       GNU Fortran (GCC) 12.2.0
─  running under: macOS Sonoma 14.5
─  using session charset: UTF-8
─  using options ‘--no-manual --as-cran’
✔  checking for file ‘JointFPM/DESCRIPTION’
─  checking extension type ... Package
─  this is package ‘JointFPM’ version ‘1.2.0.9000’
─  package encoding: UTF-8
✔  checking package namespace information
✔  checking package dependencies (1.2s)
✔  checking if this is a source package
✔  checking if there is a namespace
✔  checking for executable files ...
✔  checking for hidden files and directories
✔  checking for portable file names ...
✔  checking for sufficient/correct file permissions
✔  checking whether package ‘JointFPM’ can be installed (2.7s)
✔  checking installed package size ...
✔  checking package directory ...
✔  checking for future file timestamps ...
✔  checking DESCRIPTION meta-information ...
✔  checking top-level files ...
✔  checking for left-over files
✔  checking index information
✔  checking package subdirectories ...
✔  checking code files for non-ASCII characters ...
✔  checking R files for syntax errors ...
✔  checking whether the package can be loaded (722ms)
✔  checking whether the package can be loaded with stated dependencies (676ms)
✔  checking whether the package can be unloaded cleanly (701ms)
✔  checking whether the namespace can be loaded with stated dependencies (686ms)
✔  checking whether the namespace can be unloaded cleanly (695ms)
✔  checking loading without being on the library search path (739ms)
✔  checking dependencies in R code (1.4s)
✔  checking S3 generic/method consistency (741ms)
✔  checking replacement functions (667ms)
✔  checking foreign function calls (687ms)
✔  checking R code for possible problems (3.7s)
✔  checking Rd files ...
✔  checking Rd metadata ...
✔  checking Rd line widths ...
✔  checking Rd cross-references ...
✔  checking for missing documentation entries (683ms)
✔  checking for code/documentation mismatches (2.1s)
✔  checking Rd \usage sections (850ms)
✔  checking Rd contents ...
✔  checking for unstated dependencies in examples ...
✔  checking contents of ‘data’ directory ...
✔  checking data for non-ASCII characters ...
✔  checking LazyData
✔  checking data for ASCII and uncompressed saves ...
✔  checking examples (1.6s)
✔  checking for unstated dependencies in ‘tests’ ...
─  checking tests ...
   Running the tests in ‘tests/testthat.R’ failed.
   Last 13 lines of output:
     ── Failure ('test-predict.JointFPM.R:496:3'): Integration with GQ works ────────
     Snapshot of code has changed:
          old                 | new                     
      [8] Output              | Output              [8] 
      [9]     stop        fit |     stop        fit [9] 
     [10]   1    1 0.03450826 |   1    1 0.03450826 [10]
     [11]   2   50 2.42961444 -   2   50 2.42961445 [11]
     [12]   3  100 3.95690620 -   3  100 3.95690622 [12]
     
     * Run `testthat::snapshot_accept('predict.JointFPM')` to accept the change.
     * Run `testthat::snapshot_review('predict.JointFPM')` to interactively review the change.
     
     [ FAIL 1 | WARN 0 | SKIP 0 | PASS 32 ]
     Error: Test failures
     Execution halted
✔  checking for non-standard things in the check directory ...
✔  checking for detritus in the temp directory
   
   See
     ‘/Users/ellessenne/R-dev/JointFPM.Rcheck/00check.log’
   for details.
   
   
── R CMD check results ─────────────────────────────────────────────────────────────────────────────────────── JointFPM 1.2.0.9000 ────
Duration: 3m 51.1s

❯ checking tests ...
  See below...

── Test failures ──────────────────────────────────────────────────────────────────────────────────────────────────────── testthat ────

> # This file is part of the standard setup for testthat.
> # It is recommended that you do not modify it.
> #
> # Where should you do additional test configuration?
> # Learn more about the roles of various files in:
> # * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
> # * https://testthat.r-lib.org/articles/special-files.html
> 
> library(testthat)
> library(JointFPM)
> 
> test_check("JointFPM")
Starting 2 test processes
[ FAIL 1 | WARN 0 | SKIP 0 | PASS 32 ]

══ Failed tests ════════════════════════════════════════════════════════════════
── Failure ('test-predict.JointFPM.R:496:3'): Integration with GQ works ────────
Snapshot of code has changed:
     old                 | new                     
 [8] Output              | Output              [8] 
 [9]     stop        fit |     stop        fit [9] 
[10]   1    1 0.03450826 |   1    1 0.03450826 [10]
[11]   2   50 2.42961444 -   2   50 2.42961445 [11]
[12]   3  100 3.95690620 -   3  100 3.95690622 [12]

* Run `testthat::snapshot_accept('predict.JointFPM')` to accept the change.
* Run `testthat::snapshot_review('predict.JointFPM')` to interactively review the change.

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 32 ]
Error: Test failures
Execution halted

1 error ✖ | 0 warnings ✔ | 0 notes ✔
Error: R CMD check found ERRORs
Execution halted

Exited with status 1.
```